### PR TITLE
Avoid warnings in Ansible 2.3+

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,9 @@
 - include: install.yml
 
 - include: users.yml
-  when: "{{ docker_pi_group_users|length > 0 }}"
+  when: docker_pi_group_users|length > 0
 
 - include: login.yml
   when:
-    - "{{ docker_pi_hub_username|default('') != '' }}"
-    - "{{ docker_pi_hub_password|default('') != '' }}"
+    - docker_pi_hub_username|default('') != ''
+    - docker_pi_hub_password|default('') != ''


### PR DESCRIPTION
Fixes #6 by removing J2 curly brace syntax